### PR TITLE
Update Models and Buttons

### DIFF
--- a/backend/db/migrate/20181201172459_update_buttons.rb
+++ b/backend/db/migrate/20181201172459_update_buttons.rb
@@ -1,0 +1,7 @@
+class UpdateButtons < ActiveRecord::Migration[5.2]
+  def change
+    change_column :buttons, :created_at, :datetime, null: true
+    change_column :buttons, :updated_at, :datetime, null: true
+    add_column :buttons, :synthetic, :boolean
+  end
+end

--- a/backend/db/migrate/20181201172930_update_models.rb
+++ b/backend/db/migrate/20181201172930_update_models.rb
@@ -1,0 +1,5 @@
+class UpdateModels < ActiveRecord::Migration[5.2]
+  def change
+    add_column :models, :mobile, :boolean
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_01_062710) do
+ActiveRecord::Schema.define(version: 2018_12_01_172930) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,18 +19,20 @@ ActiveRecord::Schema.define(version: 2018_12_01_062710) do
     t.string "text"
     t.integer "position"
     t.integer "ctd"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.boolean "mobile"
     t.integer "age"
     t.integer "gender"
     t.integer "region"
+    t.boolean "synthetic"
   end
 
   create_table "models", force: :cascade do |t|
     t.jsonb "combination"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "mobile"
   end
 
 end

--- a/backend/log/development.log
+++ b/backend/log/development.log
@@ -254,3 +254,53 @@ Migrating to ChangeButtons (20181201062710)
   ↳ bin/rails:9
   [1m[35m (0.1ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
   ↳ bin/rails:9
+  [1m[35m (0.2ms)[0m  [1m[34mSELECT pg_try_advisory_lock(6420278694242605500)[0m
+  ↳ bin/rails:9
+  [1m[35m (1.7ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+  ↳ bin/rails:9
+Migrating to UpdateButtons (20181201172459)
+  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
+  ↳ bin/rails:9
+  [1m[35m (4.1ms)[0m  [1m[35mALTER TABLE "buttons" ALTER COLUMN "created_at" TYPE timestamp, ALTER "created_at" DROP NOT NULL[0m
+  ↳ db/migrate/20181201172459_update_buttons.rb:3
+  [1m[35m (0.5ms)[0m  [1m[35mALTER TABLE "buttons" ALTER COLUMN "updated_at" TYPE timestamp, ALTER "updated_at" DROP NOT NULL[0m
+  ↳ db/migrate/20181201172459_update_buttons.rb:4
+  [1m[35m (0.6ms)[0m  [1m[35mALTER TABLE "buttons" ADD "synthetic" boolean[0m
+  ↳ db/migrate/20181201172459_update_buttons.rb:5
+  [1m[36mActiveRecord::SchemaMigration Create (0.3ms)[0m  [1m[32mINSERT INTO "schema_migrations" ("version") VALUES ($1) RETURNING "version"[0m  [["version", "20181201172459"]]
+  ↳ bin/rails:9
+  [1m[35m (2.3ms)[0m  [1m[35mCOMMIT[0m
+  ↳ bin/rails:9
+  [1m[36mActiveRecord::InternalMetadata Load (5.0ms)[0m  [1m[34mSELECT  "ar_internal_metadata".* FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 LIMIT $2[0m  [["key", "environment"], ["LIMIT", 1]]
+  ↳ bin/rails:9
+  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
+  ↳ bin/rails:9
+  [1m[35m (0.1ms)[0m  [1m[35mCOMMIT[0m
+  ↳ bin/rails:9
+  [1m[35m (0.2ms)[0m  [1m[34mSELECT pg_advisory_unlock(6420278694242605500)[0m
+  ↳ bin/rails:9
+  [1m[35m (0.2ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+  ↳ bin/rails:9
+  [1m[35m (0.1ms)[0m  [1m[34mSELECT pg_try_advisory_lock(6420278694242605500)[0m
+  ↳ bin/rails:9
+  [1m[35m (0.4ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+  ↳ bin/rails:9
+Migrating to UpdateModels (20181201172930)
+  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
+  ↳ bin/rails:9
+  [1m[35m (0.4ms)[0m  [1m[35mALTER TABLE "models" ADD "mobile" boolean[0m
+  ↳ db/migrate/20181201172930_update_models.rb:3
+  [1m[36mActiveRecord::SchemaMigration Create (0.2ms)[0m  [1m[32mINSERT INTO "schema_migrations" ("version") VALUES ($1) RETURNING "version"[0m  [["version", "20181201172930"]]
+  ↳ bin/rails:9
+  [1m[35m (0.9ms)[0m  [1m[35mCOMMIT[0m
+  ↳ bin/rails:9
+  [1m[36mActiveRecord::InternalMetadata Load (0.3ms)[0m  [1m[34mSELECT  "ar_internal_metadata".* FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 LIMIT $2[0m  [["key", "environment"], ["LIMIT", 1]]
+  ↳ bin/rails:9
+  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
+  ↳ bin/rails:9
+  [1m[35m (0.1ms)[0m  [1m[35mCOMMIT[0m
+  ↳ bin/rails:9
+  [1m[35m (0.2ms)[0m  [1m[34mSELECT pg_advisory_unlock(6420278694242605500)[0m
+  ↳ bin/rails:9
+  [1m[35m (0.2ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+  ↳ bin/rails:9


### PR DESCRIPTION
To reflect whether data is either synthetic or not for the Buttons table.
Making  the created_at and update_at values being ok to be null as DS is saving directly to DB. Models also has a mobile boolean.